### PR TITLE
Hide desktop notification banner, more unreads buttons, and activity …

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,3 +1,4 @@
-.css-selector {
+/* "more unreads" button, enable desktop notifications banner, and mention badge */
+.p-channel_sidebar__banner--unreads, .p-workspace_banner__desktop-notifications, .c-mention_badge {
   display: none !important;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
   {
     "resources": ["css/*.css"],
     "extension_ids": [
-      ""
+      "lohigdpnlkaabdijopklelgffjopnghf"
     ]
     }
   ],

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -3,7 +3,7 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (
     changeInfo.status === "complete" &&
     tabUrl &&
-    tabUrl.includes("someurl.com")
+    tabUrl.includes("app.slack.com")
   ) {
     chrome.scripting.insertCSS({
       target: { tabId: tabId },


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Overview
After the most recent Slack update, this hides the desktop notifications banner the "more unreads" buttons, and the badge icon that appears next to the activity section in the sidebar. (On the website it's next to the "more" section.) 
<!--- Describe your changes in detail -->

## Background
I personally found the changes to have a negative impact on my customer experience. There wasn't a way to turn them off using Slack's settings, so I decided to make a browser extension to do this instead. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test by first git cloning this repo. You can then load the unpacked extension into Chrome. Here are more detailed instructions via the [Chrome developers](https://developer.chrome.com/docs/extensions/mv3/getstarted/development-basics/#load-unpacked) site. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
