### PR TITLE
Feat/remove blur

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -2,3 +2,8 @@
 .p-channel_sidebar__banner--unreads, .p-workspace_banner__desktop-notifications, .c-mention_badge {
   display: none !important;
 }
+
+
+.c-message_kit__hidden_message_blur {
+  filter: blur(0) !important;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide Slack Activity",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "This hides the activity notification badge icon and the more unreads buttons on the Slack website.",
    "permissions": ["scripting"],
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -1,6 +1,28 @@
-<html>
-    <body>
-        <h2>Hide Slack Activity</h2>
-        <script src="popup.js" type="module"></script>
-    </body>
+<html class="popup-window" style="width: 200px">
+  <body>
+    <h2>Hide Slack Activity</h2>
+    <p>
+      version: 0.0.2 |
+      <a
+        href="https://github.com/garnetred/hide-slack-activity"
+        style="color: navy"
+        target="_blank"
+        rel="noopener noreferrer"
+        >github</a
+      >
+    </p>
+    <script src="popup.js" type="module"></script>
+    <p style="color: gray">
+      Loving this extension? <br />
+      Consider
+      <a
+        href="https://www.buymeacoffee.com/decemberthedeveloper"
+        style="font-weight: bold; color: navy"
+        target="_blank"
+        rel="noopener noreferrer"
+        >buying me a coffee</a
+      >
+      to support my work.
+    </p>
+  </body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This change removes a blur effect that hides old Slack messages in free Slack communities. 
<!--- Describe your changes in detail -->

## Background
For free Slack communities, the platform hides messages older than 90 days. 
Recently I noticed that some older messages were visible with a blur effect on top of them to hide the message. This PR removes the blur so you can read the messages. 
It also updates the popup.html file to match the formatting of my other browser extensions. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test by unpacking the browser extension locally, navigating to a free Slack community, visiting a channel with messages older than 90 days, and verifying that the messages are visible with the extension and blurred without them. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
