### PR TITLE
Feat/hide slack activity button

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -3,6 +3,10 @@
   display: none !important;
 }
 
+#activity {
+  display: none !important;
+}
+
 
 .c-message_kit__hidden_message_blur {
   filter: blur(0) !important;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide Slack Activity",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "This hides the activity notification badge icon and the more unreads buttons on the Slack website.",
    "permissions": ["scripting"],
   "icons": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This PR hides the Slack activity button on the left-hand sidebar. 
<!--- Describe your changes in detail -->

## Background
Recently I noticed that the bell icon for the activity button in the sidebar has started cycling through the most recent emoji reactions to a user's activity. This can be visually distracting for some users as noted by the [Web Accessibility Initiative](https://www.w3.org/WAI/tutorials/carousels/animations/) and currently there's no way to pause these animations, so I updated this extension to remove the button entirely. 

Long term a better solution would just prevent this mini slideshow from appearing and leave the icon as-is. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test by loading the extension locally and navigating to Slack via the browser. You should no longer see the activity bell icon on the left hand side of the page. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
