### PR TITLE
Add CSS to let users click through old threads

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -11,3 +11,7 @@
 .c-message_kit__hidden_message_blur {
   filter: blur(0) !important;
 }
+
+.c-message_kit__hidden_message_blur * {
+  pointer-events: auto !important;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This change allows users to click through and read replies to old threads. 
<!--- Describe your changes in detail -->

## Background
Recently I noticed that, although this extension removes the blur on old Slack threads (reading posts older than 90 days is a feature restricted to paid Slack communities), it was no longer possible to click through these old thread to read the replies. Instead, all of the HTML elements within the message container had the CSS property and value of `pointer-events: none`. This PR overrides that CSS to set it to the default value of `auto` instead. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can test by loading the unpacked extension according to the README instructions. 

From there, you can navigate to a particular Slack community. When you see a post older than 90 days, you should be able to click on it and read through the replies. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [ ] I have updated any relevant documentation.
