### PR TITLE
Increment version and add new css selector for truncated text

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This Chrome browser extension does the following:
 - removes the activity badge app icon
 - removes the slack activity button to hide the carousel of emojis
 - removes the blur from posts older than 90 days
-- allows users to click and read replies for posts older than 90 days.
+- allows users to click and read replies for posts older than 90 days
+- un-truncates text in messages older than 90 days.
 
 ## Tech Stack
 This project uses vanilla JS, CSS, and HTML.

--- a/css/global.css
+++ b/css/global.css
@@ -15,3 +15,9 @@
 .c-message_kit__hidden_message_blur * {
   pointer-events: auto !important;
 }
+
+[class*="truncate"] {
+  overflow: visible !important;
+  word-break: normal !important;
+  -webkit-box-orient: initial !important;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hide Slack Activity",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "This hides the activity notification badge icon and the more unreads buttons on the Slack website.",
    "permissions": ["scripting"],
   "icons": {

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
   <body>
     <h2>Hide Slack Activity</h2>
     <p>
-      version: 0.0.4 |
+      version: 0.0.5 |
       <a
         href="https://github.com/garnetred/hide-slack-activity"
         style="color: navy"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Overview
This un-truncates text from posts older than 90 days. 
<!--- Describe your changes in detail -->

## Background
Recently I noticed that, in addition to the blur, the text for old posts is now cut off. This fixes this by making overflow text visible, setting word-breaks to the default value and updating the `-webkit-box-orient` property. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Testing
You can clone the repo and switch to this branch. After that, you can load the unpacked extension to Chrome in developer mode. From there, when you navigate to Slack, you should no longer see truncated messages. 
<!--- Please describe in detail how to test these changes. -->

## Screenshot(s):

<!-- Please include any screenshots if applicable. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have self-reviewed my code and added comments where relevant.
- [x] I have updated any relevant documentation.
